### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.6.0
 attrs==22.2.0
-backports.zoneinfo==0.2.1
+backports.zoneinfo;python_version<"3.9"
 cattrs==22.2.0
 certifi==2022.12.7
 charset-normalizer==3.1.0


### PR DESCRIPTION
backports.zoneinfo has limited support in Python 3.9+. Changed to ignore if there's a version of Python installed that's 3.9 or higher. Ref issue #31 